### PR TITLE
Remove branch specification in Coveralls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #pplog-queue
 
-[![Coverage Status](https://coveralls.io/repos/gouf/pplog-queue/badge.png?branch=dev)](https://coveralls.io/r/gouf/pplog-queue?branch=dev)
+[![Coverage Status](https://coveralls.io/repos/gouf/pplog-queue/badge.png?branch=dev)](https://coveralls.io/r/gouf/pplog-queue)
 [![Build Status](https://travis-ci.org/gouf/pplog-queue.png?branch=dev)](https://travis-ci.org/gouf/pplog-queue)
 
 ぽえみをちょっと便利に。


### PR DESCRIPTION
- Coveralls バッジのブランチ指定を削除
